### PR TITLE
Fix to compile under Mac OSX 10.9 with Qt 4.8.5 from MacPorts 

### DIFF
--- a/misc/global.h
+++ b/misc/global.h
@@ -151,6 +151,7 @@ typedef QList<GlRect> Thumbnails;
 
 
 class WatcherBase : public QObject {
+    Q_OBJECT
 public:
     QFileSystemWatcher *watcher;
 public:


### PR DESCRIPTION
Hi,

Here's a simple fix to compile Rekall under Mac OSX 10.9, tested with Qt 4.8.5 installed through MacPorts.

Best regards,
Christian
